### PR TITLE
Fixed SQL statement building logic for RemoveFilteredPolicy()

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -444,8 +444,8 @@ func (a *Adapter) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int,
 	sql := `delete from ` + a.table + ` where ptype = @ptype`
 	params := map[string]interface{}{"ptype": ptype}
 	for k, v := range selector {
-		sql = sql + fmt.Sprintf(" and %v = @val", k)
-		params["val"] = v
+		sql = sql + fmt.Sprintf(" and %s = @%s", k, k)
+		params[k] = v
 	}
 
 	_, err := a.client.ReadWriteTransaction(context.Background(),


### PR DESCRIPTION
When building the SQL statement to remove policy rules that match the given filter from the storage, the existing code loses the information built up in the `selector` and sets all `WHERE` clauses to match on the the single value `"val"`.
This PR restores the proper behavior for the `RemoveFilteredPolicy` method.